### PR TITLE
Lesson 5: Prefix Sums | task 2: Count Dividends

### DIFF
--- a/src/CountDiv/DivisionsCounter.php
+++ b/src/CountDiv/DivisionsCounter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HcsOmot\Codility\Lessons\CountDiv;
+
+class DivisionsCounter
+{
+    public function findNumberOfDividendsInRangeForDivisionWithPredefinedDivisor(
+        int $rangeStart,
+        int $rangeEnd,
+        int $divisor
+    ): int {
+        return (int) floor($rangeEnd / $divisor) - (int) ceil($rangeStart / $divisor) + 1;
+    }
+}

--- a/tests/DivisionsCounterTest.php
+++ b/tests/DivisionsCounterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HcsOmot\Codility\Tests;
+
+use HcsOmot\Codility\Lessons\CountDiv\DivisionsCounter;
+use PHPUnit\Framework\TestCase;
+
+class DivisionsCounterTest extends TestCase
+{
+    /**
+     * @dataProvider provideRangeLimitsAndADivisor
+     */
+    public function testfindNumberOfDividendsInRangeForDivisionWithPredefinedDivisor(int $rangeStart, int $rangeEnd, int $divisor,
+        int $expectedNumberOfDividends)
+    {
+        $resultFinder = new DivisionsCounter();
+
+        $this->assertEquals($expectedNumberOfDividends, $resultFinder->findNumberOfDividendsInRangeForDivisionWithPredefinedDivisor($rangeStart, $rangeEnd, $divisor));
+    }
+
+    public function provideRangeLimitsAndADivisor()
+    {
+        return [
+            [1, 2, 2, 1],
+            [1, 7, 2, 3],
+            [6, 11, 2, 3],
+            [1, 15, 3, 5],
+            [1, 15, 7, 2],
+            [10, 10, 5, 1], // edge case - range endpoint are same
+            [10, 10, 7, 0], // edge case - range endpoint are same
+            [0, 10, 3, 4],
+            [0, 0, 3, 1],
+            [0, 1, 1, 2],
+            [0, 14, 2, 8],
+        ];
+    }
+}


### PR DESCRIPTION
Solve DivisionCounter for O(N)

This was a tough one to crack!

For a given range, the max int that's divisible by K is the first lower
integer value of range end divided by K (it's the floor of range end / K).

The min int that's divisible by K is first greater integer value of range
start divided by K (that's the ceil of range start / K).

To count the number of divisible integers within a range, we need to
subtract the range start result (0 .. range start) from range end result
(0 .. range end).

The trick is to add 1 to the final result, because we're subtracting the
range start result, which is supposed to be included in the overall result.

For result evaluation, see:
  https://codility.com/demo/results/trainingMM8XZV-UTD/